### PR TITLE
Run builds with github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: Build static ffmpeg
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  package-linux:
+    runs-on: ubuntu-latest
+    env:
+      ARCH: x86_64
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: sudo apt-get install nasm
+    - name: Build
+      run: |
+        mkdir artifacts
+        ./build-linux.sh
+        mv ffmpeg-*-audio-linux-* artifacts
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: ffmpeg-${{ runner.os }}-${{ env.ARCH }}
+        path: artifacts/
+
+  package-macos:
+    runs-on: macos-latest
+    env:
+      ARCH: x86_64
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: brew install nasm
+    - name: Build
+      run: |
+        mkdir artifacts
+        ./build-macos.sh
+        mv ffmpeg-*-audio-macos-** artifacts
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: ffmpeg-${{ runner.os }}-${{ env.ARCH }}
+        path: artifacts/
+
+  # package-windows:
+  #   runs-on: windows-latest
+  #   env:
+  #     ARCH: x86_64
+  #   steps:
+  #   - uses: actions/checkout@v1
+  #   - name: Build
+  #     shell: bash
+  #     run: |
+  #       mkdir artifacts
+  #       ./build-windows.sh
+  #       mv ffmpeg-*-audio-windows-x86_64 artifacts
+  #   - name: Archive production artifacts
+  #     uses: actions/upload-artifact@v1
+  #     with:
+  #       name: ffmpeg-${{ runner.os }}-${{ env.ARCH }}
+  #       path: artifacts/

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -22,15 +22,14 @@ trap 'rm -rf $BUILD_DIR' EXIT
 cd $BUILD_DIR
 tar --strip-components=1 -xf $BASE_DIR/$FFMPEG_TARBALL
 
-OSX_SDK=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk
+OSX_SDK=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
 OSX_VERSION=10.6
 
 FFMPEG_CONFIGURE_FLAGS+=(
-    --prefix=$BASE_DIR/$TARGET
+	--prefix=$BASE_DIR/$TARGET
 	--enable-cross-compile
 	--target-os=darwin
 	--arch=$ARCH
-	--enable-memalign-hack
 	--extra-ldflags="-isysroot $OSX_SDK -mmacosx-version-min=$OSX_VERSION -arch $ARCH"
 	--extra-cflags="-isysroot $OSX_SDK -mmacosx-version-min=$OSX_VERSION -arch $ARCH"
 )

--- a/build-windows.sh
+++ b/build-windows.sh
@@ -25,7 +25,6 @@ tar --strip-components=1 -xf $BASE_DIR/$FFMPEG_TARBALL
 FFMPEG_CONFIGURE_FLAGS+=(
     --prefix=$BASE_DIR/$TARGET
     --extra-cflags='-static -static-libgcc -static-libstdc++'
-    --enable-memalign-hack
     --target-os=mingw32
     --arch=$ARCH
     --cross-prefix=$ARCH-w64-mingw32-

--- a/common.sh
+++ b/common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FFMPEG_VERSION=3.2.4
+FFMPEG_VERSION=4.2.2
 FFMPEG_TARBALL=ffmpeg-$FFMPEG_VERSION.tar.bz2
 FFMPEG_TARBALL_URL=http://ffmpeg.org/releases/$FFMPEG_TARBALL
 
@@ -15,7 +15,6 @@ FFMPEG_CONFIGURE_FLAGS=(
     --enable-rdft
     --enable-ffmpeg
     --disable-ffplay
-    --disable-ffserver
     --disable-network
     --disable-muxers
     --disable-demuxers


### PR DESCRIPTION
Here we go, something to get this started.

This builds on Github actions, for now only 64bit macOS and Linux builds. Also upgraded to latest ffmpeg 4.2.2.

I likely won't be able to continue working on this before next week, so I thought I'll drop what I have for now. Windows builds will probably requiring fiddling around with msys, see e.g. https://github.com/actions/starter-workflows/issues/95 .

I did not test much except verifying the executable runs. No idea if fpcalc will build with this. I upgraded to ffmpeg 4.2.2, maybe this will break something. Also the update could mean configure flags might need reexamination, e.g. there might be something new we want to disable.

Artifacts are uploaded, but download is only really feasible manually. What I would like to do is hook this up with Github releases and upload artifacts there on tagged builds. That can easily be added, see https://github.com/metabrainz/picard/blob/master/.github/workflows/package-macos.yml#L71