### PR TITLE
CI: Compress artifacts with gzip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
           for dir in $dirs
           do
             name=$(basename $dir)
-            tar cvf release/$name.tar.gz $dir
+            tar cvzf release/$name.tar.gz $dir
           done
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
The build did not explicitly set a compression algorithm for tar.

The result was that the files where not actually gzip compressed and I was unable to untar them on macOS. Fixing this by explicitly using gzip compression.