### PR TITLE
Upgrade FFmpeg to 8.1.2

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FFMPEG_VERSION=8.0
+FFMPEG_VERSION=8.1.2
 FFMPEG_TARBALL=ffmpeg-$FFMPEG_VERSION.tar.gz
 FFMPEG_TARBALL_URL=http://ffmpeg.org/releases/$FFMPEG_TARBALL
 


### PR DESCRIPTION
Bumps the pinned FFmpeg version from 8.0 to 8.1.2 (latest release). Opening as a PR to run the build matrix in CI.