### PR TITLE
Add audio encode build variant (with MP3 via libmp3lame)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,12 @@ jobs:
         arch:
           - x86_64
           - arm64
+        variant:
+          - decode
+          - encode
     env:
       ARCH: ${{ matrix.arch }}
+      FFMPEG_VARIANT: ${{ matrix.variant }}
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
@@ -34,7 +38,7 @@ jobs:
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ffmpeg-linux-${{ env.ARCH }}
+          name: ffmpeg-linux-${{ env.ARCH }}-${{ env.FFMPEG_VARIANT }}
           path: artifacts/
 
   package-windows:
@@ -43,8 +47,12 @@ jobs:
       matrix:
         arch:
           - x86_64
+        variant:
+          - decode
+          - encode
     env:
       ARCH: ${{ matrix.arch }}
+      FFMPEG_VARIANT: ${{ matrix.variant }}
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
@@ -56,7 +64,7 @@ jobs:
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ffmpeg-windows-${{ env.ARCH }}
+          name: ffmpeg-windows-${{ env.ARCH }}-${{ env.FFMPEG_VARIANT }}
           path: artifacts/
 
   package-macos:
@@ -67,8 +75,12 @@ jobs:
         target:
           - x86_64-apple-macos10.9
           - arm64-apple-macos11
+        variant:
+          - decode
+          - encode
     env:
       TARGET: ${{ matrix.target }}
+      FFMPEG_VARIANT: ${{ matrix.variant }}
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
@@ -78,7 +90,7 @@ jobs:
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ffmpeg-${{ matrix.target }}
+          name: ffmpeg-${{ matrix.target }}-${{ env.FFMPEG_VARIANT }}
           path: artifacts/
 
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /ffmpeg-*.tar.gz
+/lame-*.tar.gz
 /artifacts/
 /build.*/
+/deps.*/
+/lame.*/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/ffmpeg-*.tar.gz
+/artifacts/
+/build.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+- `encode` build variant with native audio encoders/muxers and MP3 encoding via
+  a statically linked libmp3lame. Selected with `FFMPEG_VARIANT=encode`.
+- `arm64-linux-gnu` builds.
+
+### Changed
+- Upgraded FFmpeg to 8.1.2.
 
 ## [4.2.2-5] - 2020-02-19
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,17 +1,50 @@
 Static audio-only FFmpeg builds
 ===============================
 
-This project contains scripts for small static audio-only FFmpeg builds that are used
-for Chromaprint packaging.
+This project contains scripts for small static audio-only FFmpeg builds. The
+default builds are used for Chromaprint packaging (`fpcalc`), and there is an
+additional variant that can also encode audio.
 
-Building is done using GitHub Actions. You can find the built binaries on the releases page.
+Building is done using GitHub Actions. You can find the built binaries on the
+releases page.
+
+The current FFmpeg version is **8.1.2**. The builds are LGPL-licensed (no
+`--enable-gpl` or `--enable-nonfree`).
+
+Variants
+--------
+
+Each platform is built in two variants, selected with the `FFMPEG_VARIANT`
+environment variable:
+
+  - `decode` (default, output label `audio`) — audio **decoders** only, as
+    needed by Chromaprint. This is the small, fully self-contained build.
+  - `encode` (output label `audio-encode`) — everything in `decode` plus native
+    audio **encoders** and muxers for transcoding, including MP3 via a
+    statically linked [LAME](https://lame.sourceforge.io/), built from source by
+    `build-lame.sh`.
 
 Supported platforms:
 
   - Linux
-      * `x86\_64-linux-gnu`
+      * `x86_64-linux-gnu`
+      * `arm64-linux-gnu`
   - Windows
-      * `x86\_64-w64-mingw32`
+      * `x86_64-w64-mingw32`
   - macOS
       * `x86_64-apple-macos10.9` (macOS Mavericks and newer on Intel CPU)
       * `arm64-apple-macos11` (macOS Big Sur and newer on Apple M1 CPU)
+
+Building locally
+----------------
+
+The build scripts read the target architecture and variant from environment
+variables, for example:
+
+```sh
+ARCH=x86_64 FFMPEG_VARIANT=decode ./build-linux.sh
+ARCH=x86_64 FFMPEG_VARIANT=encode ./build-linux.sh
+TARGET=arm64-apple-macos11 FFMPEG_VARIANT=encode ./build-macos.sh
+```
+
+The resulting tree is placed under `artifacts/`.

--- a/build-lame.sh
+++ b/build-lame.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Builds a static libmp3lame into $LAME_PREFIX. Any extra arguments are passed
+# straight to LAME's configure, which is how callers supply the per-target
+# toolchain settings (e.g. --host, CC=..., CFLAGS=...).
+
+set -eu
+
+cd $(dirname $0)
+BASE_DIR=$(pwd)
+
+source common.sh
+
+: ${LAME_PREFIX?}
+
+if [ ! -e $LAME_TARBALL ]
+then
+	curl -s -L -o $LAME_TARBALL $LAME_TARBALL_URL
+fi
+
+BUILD_DIR=$(mktemp -d -p $(pwd) lame.XXXXXXXX)
+trap 'rm -rf $BUILD_DIR' EXIT
+
+cd $BUILD_DIR
+tar --strip-components=1 -xf $BASE_DIR/$LAME_TARBALL
+
+./configure \
+    --prefix=$LAME_PREFIX \
+    --enable-static \
+    --disable-shared \
+    --disable-frontend \
+    --disable-gtktest \
+    "$@"
+
+make
+make install

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -14,7 +14,7 @@ fi
 
 : ${ARCH?}
 
-OUTPUT_DIR=artifacts/ffmpeg-$FFMPEG_VERSION-audio-$ARCH-linux-gnu
+OUTPUT_DIR=artifacts/ffmpeg-$FFMPEG_VERSION-$FFMPEG_VARIANT_LABEL-$ARCH-linux-gnu
 
 case $ARCH in
     x86_64)

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -16,11 +16,15 @@ fi
 
 OUTPUT_DIR=artifacts/ffmpeg-$FFMPEG_VERSION-$FFMPEG_VARIANT_LABEL-$ARCH-linux-gnu
 
+# Per-target arguments for build-lame.sh (used by the encode variant).
+LAME_CONFIGURE_ARGS=(CFLAGS=-fPIC)
+
 case $ARCH in
     x86_64)
         ;;
     i686)
         FFMPEG_CONFIGURE_FLAGS+=(--cc="gcc -m32")
+        LAME_CONFIGURE_ARGS=(--host=i686-linux-gnu "CC=gcc -m32" "CFLAGS=-fPIC -m32")
         ;;
     arm64)
         FFMPEG_CONFIGURE_FLAGS+=(
@@ -29,6 +33,7 @@ case $ARCH in
             --target-os=linux
             --arch=aarch64
         )
+        LAME_CONFIGURE_ARGS+=(--host=aarch64-linux-gnu)
         ;;
     arm*)
         FFMPEG_CONFIGURE_FLAGS+=(
@@ -37,6 +42,7 @@ case $ARCH in
             --target-os=linux
             --arch=arm
         )
+        LAME_CONFIGURE_ARGS+=(--host=arm-linux-gnueabihf)
         case $ARCH in
             armv7-a)
                 FFMPEG_CONFIGURE_FLAGS+=(
@@ -69,7 +75,17 @@ case $ARCH in
 esac
 
 BUILD_DIR=$(mktemp -d -p $(pwd) build.XXXXXXXX)
-trap 'rm -rf $BUILD_DIR' EXIT
+DEPS_DIR=$(mktemp -d -p $(pwd) deps.XXXXXXXX)
+trap 'rm -rf $BUILD_DIR $DEPS_DIR' EXIT
+
+if [ "$FFMPEG_VARIANT" = encode ]
+then
+    LAME_PREFIX=$DEPS_DIR ./build-lame.sh "${LAME_CONFIGURE_ARGS[@]}"
+    FFMPEG_CONFIGURE_FLAGS+=(
+        --extra-cflags=-I$DEPS_DIR/include
+        --extra-ldflags=-L$DEPS_DIR/lib
+    )
+fi
 
 cd $BUILD_DIR
 tar --strip-components=1 -xf $BASE_DIR/$FFMPEG_TARBALL

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -17,9 +17,13 @@ fi
 case $TARGET in
     x86_64-*)
         ARCH="x86_64"
+        LAME_HOST_ARCH="x86_64"
         ;;
     arm64-*)
         ARCH="arm64"
+        # LAME 3.100's config.sub predates Apple silicon and knows aarch64,
+        # not arm64, so use that for the --host triple.
+        LAME_HOST_ARCH="aarch64"
         ;;
     *)
         echo "Unknown target: $TARGET"
@@ -30,7 +34,20 @@ esac
 OUTPUT_DIR=artifacts/ffmpeg-$FFMPEG_VERSION-$FFMPEG_VARIANT_LABEL-$TARGET
 
 BUILD_DIR=$BASE_DIR/$(mktemp -d build.XXXXXXXX)
-trap 'rm -rf $BUILD_DIR' EXIT
+DEPS_DIR=$BASE_DIR/$(mktemp -d deps.XXXXXXXX)
+trap 'rm -rf $BUILD_DIR $DEPS_DIR' EXIT
+
+if [ "$FFMPEG_VARIANT" = encode ]
+then
+    LAME_PREFIX=$DEPS_DIR ./build-lame.sh \
+        --host=$LAME_HOST_ARCH-apple-darwin \
+        "CC=/usr/bin/clang -target $TARGET" \
+        "CFLAGS=-fPIC -target $TARGET"
+    FFMPEG_CONFIGURE_FLAGS+=(
+        --extra-cflags=-I$DEPS_DIR/include
+        --extra-ldflags=-L$DEPS_DIR/lib
+    )
+fi
 
 cd $BUILD_DIR
 tar --strip-components=1 -xf $BASE_DIR/$FFMPEG_TARBALL

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -27,7 +27,7 @@ case $TARGET in
         ;;
 esac
 
-OUTPUT_DIR=artifacts/ffmpeg-$FFMPEG_VERSION-audio-$TARGET
+OUTPUT_DIR=artifacts/ffmpeg-$FFMPEG_VERSION-$FFMPEG_VARIANT_LABEL-$TARGET
 
 BUILD_DIR=$BASE_DIR/$(mktemp -d build.XXXXXXXX)
 trap 'rm -rf $BUILD_DIR' EXIT

--- a/build-windows.sh
+++ b/build-windows.sh
@@ -17,7 +17,17 @@ fi
 OUTPUT_DIR=artifacts/ffmpeg-$FFMPEG_VERSION-$FFMPEG_VARIANT_LABEL-$ARCH-w64-mingw32
 
 BUILD_DIR=$(mktemp -d -p $(pwd) build.XXXXXXXX)
-trap 'rm -rf $BUILD_DIR' EXIT
+DEPS_DIR=$(mktemp -d -p $(pwd) deps.XXXXXXXX)
+trap 'rm -rf $BUILD_DIR $DEPS_DIR' EXIT
+
+if [ "$FFMPEG_VARIANT" = encode ]
+then
+    LAME_PREFIX=$DEPS_DIR ./build-lame.sh --host=$ARCH-w64-mingw32
+    FFMPEG_CONFIGURE_FLAGS+=(
+        --extra-cflags=-I$DEPS_DIR/include
+        --extra-ldflags=-L$DEPS_DIR/lib
+    )
+fi
 
 cd $BUILD_DIR
 tar --strip-components=1 -xf $BASE_DIR/$FFMPEG_TARBALL

--- a/build-windows.sh
+++ b/build-windows.sh
@@ -14,7 +14,7 @@ fi
 
 : ${ARCH?}
 
-OUTPUT_DIR=artifacts/ffmpeg-$FFMPEG_VERSION-audio-$ARCH-w64-mingw32
+OUTPUT_DIR=artifacts/ffmpeg-$FFMPEG_VERSION-$FFMPEG_VARIANT_LABEL-$ARCH-w64-mingw32
 
 BUILD_DIR=$(mktemp -d -p $(pwd) build.XXXXXXXX)
 trap 'rm -rf $BUILD_DIR' EXIT

--- a/common.sh
+++ b/common.sh
@@ -4,11 +4,18 @@ FFMPEG_VERSION=8.1.2
 FFMPEG_TARBALL=ffmpeg-$FFMPEG_VERSION.tar.gz
 FFMPEG_TARBALL_URL=http://ffmpeg.org/releases/$FFMPEG_TARBALL
 
+# LAME is the MP3 encoder used by the encode variant. It is LGPL, which matches
+# the license of these FFmpeg builds (configured without --enable-gpl), and is
+# built statically from source for each target by build-lame.sh.
+LAME_VERSION=3.100
+LAME_TARBALL=lame-$LAME_VERSION.tar.gz
+LAME_TARBALL_URL=https://downloads.sourceforge.net/project/lame/lame/$LAME_VERSION/$LAME_TARBALL
+
 # Which build variant to produce:
 #   decode - audio decoders only (default, used for Chromaprint/fpcalc)
-#   encode - decoders plus native audio encoders/muxers for transcoding
-# External-library codecs (e.g. MP3 via libmp3lame) are intentionally never
-# included, to keep the builds fully self-contained.
+#   encode - decoders plus native audio encoders/muxers for transcoding,
+#            including MP3 encoding via a statically linked libmp3lame
+# No GPL-only or nonfree codecs are ever included, so the builds stay LGPL.
 FFMPEG_VARIANT=${FFMPEG_VARIANT:-decode}
 
 FFMPEG_CONFIGURE_FLAGS=(
@@ -195,9 +202,14 @@ case $FFMPEG_VARIANT in
         ;;
     encode)
         FFMPEG_VARIANT_LABEL=audio-encode
-        # Native audio encoders (no external libraries). Note there is no
-        # native MP3 encoder; MP3 output would require libmp3lame/libshine.
+        # Audio encoders. MP3 has no native FFmpeg encoder, so it is provided by
+        # libmp3lame, which the platform build scripts compile statically and
+        # point at via --extra-cflags/--extra-ldflags.
         FFMPEG_CONFIGURE_FLAGS+=(
+            --enable-libmp3lame
+            --enable-encoder=libmp3lame
+            --enable-muxer=mp3
+
             --enable-encoder=aac
             --enable-encoder=ac3
             --enable-encoder=eac3

--- a/common.sh
+++ b/common.sh
@@ -4,6 +4,13 @@ FFMPEG_VERSION=8.1.2
 FFMPEG_TARBALL=ffmpeg-$FFMPEG_VERSION.tar.gz
 FFMPEG_TARBALL_URL=http://ffmpeg.org/releases/$FFMPEG_TARBALL
 
+# Which build variant to produce:
+#   decode - audio decoders only (default, used for Chromaprint/fpcalc)
+#   encode - decoders plus native audio encoders/muxers for transcoding
+# External-library codecs (e.g. MP3 via libmp3lame) are intentionally never
+# included, to keep the builds fully self-contained.
+FFMPEG_VARIANT=${FFMPEG_VARIANT:-decode}
+
 FFMPEG_CONFIGURE_FLAGS=(
     --disable-shared
     --enable-static
@@ -180,3 +187,66 @@ FFMPEG_CONFIGURE_FLAGS=(
     --enable-parser=tak
     --enable-parser=vorbis
 )
+
+# Label used in the output directory / artifact name for each variant.
+case $FFMPEG_VARIANT in
+    decode)
+        FFMPEG_VARIANT_LABEL=audio
+        ;;
+    encode)
+        FFMPEG_VARIANT_LABEL=audio-encode
+        # Native audio encoders (no external libraries). Note there is no
+        # native MP3 encoder; MP3 output would require libmp3lame/libshine.
+        FFMPEG_CONFIGURE_FLAGS+=(
+            --enable-encoder=aac
+            --enable-encoder=ac3
+            --enable-encoder=eac3
+            --enable-encoder=mp2
+            --enable-encoder=flac
+            --enable-encoder=alac
+            --enable-encoder=wavpack
+            --enable-encoder=tta
+            --enable-encoder=opus
+            --enable-encoder=vorbis
+            --enable-encoder=wmav1
+            --enable-encoder=wmav2
+            --enable-encoder=pcm_s16le
+            --enable-encoder=pcm_s16be
+            --enable-encoder=pcm_s24le
+            --enable-encoder=pcm_s32le
+            --enable-encoder=pcm_f32le
+            --enable-encoder=pcm_u8
+            --enable-encoder=pcm_alaw
+            --enable-encoder=pcm_mulaw
+
+            --enable-muxer=wav
+            --enable-muxer=w64
+            --enable-muxer=aiff
+            --enable-muxer=flac
+            --enable-muxer=mp4
+            --enable-muxer=ipod
+            --enable-muxer=mov
+            --enable-muxer=ogg
+            --enable-muxer=oga
+            --enable-muxer=opus
+            --enable-muxer=wv
+            --enable-muxer=ac3
+            --enable-muxer=eac3
+            --enable-muxer=asf
+            --enable-muxer=mp2
+            --enable-muxer=adts
+            --enable-muxer=latm
+            --enable-muxer=tta
+            --enable-muxer=au
+            --enable-muxer=caf
+            --enable-muxer=matroska
+
+            # Needed for sample-rate / sample-format conversion when transcoding.
+            --enable-filter=aresample
+        )
+        ;;
+    *)
+        echo "Unknown variant: $FFMPEG_VARIANT" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Adds a second build variant that can encode audio, addressing requests like #17.

## What changed
- New `FFMPEG_VARIANT` flag in `common.sh` (`decode` default, or `encode`).
  - `decode` — unchanged behavior; output label stays `audio` (backward compatible).
  - `encode` — adds native audio encoders + muxers + the `aresample` filter; output label `audio-encode`.
- **MP3 encoding** via a statically linked **libmp3lame 3.100**, built from source per target by the new `build-lame.sh` and linked into FFmpeg.
- CI matrix builds both variants on all platforms; artifact names include the variant.
- Added `.gitignore` (downloaded tarballs, build/deps temp dirs).
- README/CHANGELOG updated for the variants, FFmpeg 8.1.2, and the `arm64-linux-gnu` target.

## Encoders in the encode variant
MP3 (libmp3lame), AAC (native), ALAC, FLAC, WavPack, TTA, AC-3/E-AC-3, MP2, Opus, Vorbis, WMA v1/v2, and a PCM set — each with a matching muxer.

## Validation
All 10 build jobs + release are green. The `arm64-linux-gnu` encode artifact was run natively on aarch64 and verified end-to-end: encodes MP3/AAC/FLAC and round-trips an MP3 back to WAV.

## Notes
- No native MP3 encoder exists in FFmpeg, so MP3 is provided by libmp3lame (LGPL). Nonfree encoders (e.g. libfdk_aac) are not included.
- The decode variant is unchanged and stays fully self-contained.