### PR TITLE
Add 32-bit (i686) Windows build to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         arch:
           - x86_64
+          - i686
         variant:
           - decode
           - encode

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Supported platforms:
       * `arm64-linux-gnu`
   - Windows
       * `x86_64-w64-mingw32`
+      * `i686-w64-mingw32` (32-bit)
   - macOS
       * `x86_64-apple-macos10.9` (macOS Mavericks and newer on Intel CPU)
       * `arm64-apple-macos11` (macOS Big Sur and newer on Apple M1 CPU)


### PR DESCRIPTION
Adds `i686` as a cross-compilation target to the existing mingw-w64 Windows job. Opening this PR mainly to exercise the build in CI and confirm the i686 toolchain + FFmpeg configure work as expected.